### PR TITLE
use date and time pickers for dates and times

### DIFF
--- a/osler/appointment/forms.py
+++ b/osler/appointment/forms.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from builtins import object
-from django.forms import ModelForm, TimeInput
+from django.forms import ModelForm, TimeInput, TextInput
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
@@ -16,8 +16,8 @@ class AppointmentForm(ModelForm):
                   'patient']
 
         widgets = {
-            # 'clindate': DateTimePicker(options={"format": "YYYY-MM-DD"}),
-            'clintime': TimeInput(format='%H:%M')
+            'clindate': TextInput(attrs={'type': 'date'}),
+            'clintime': TimeInput(format='%H:%M', attrs={'type': 'time'})
         }
 
     def __init__(self, *args, **kwargs):

--- a/osler/core/forms.py
+++ b/osler/core/forms.py
@@ -2,7 +2,7 @@
 
 from django.forms import (
     Form, CharField, ModelForm, EmailField, CheckboxSelectMultiple,
-    ModelMultipleChoiceField, CheckboxInput)
+    ModelMultipleChoiceField, CheckboxInput, TextInput)
 from django.contrib.auth.forms import AuthenticationForm
 
 from django.conf import settings
@@ -41,14 +41,17 @@ class PatientForm(ModelForm):
         exclude = ['demographics']
         if not settings.OSLER_DISPLAY_CASE_MANAGERS:
             exclude.append('case_managers')
+        widgets = {
+            'date_of_birth': TextInput(attrs={'type': 'date'}),
+        }
 
     if settings.OSLER_DISPLAY_CASE_MANAGERS:
         case_managers = ModelMultipleChoiceField(
             required=False,
             queryset=get_user_model().objects
-                .filter(groups__permissions__codename='case_manage_Patient')
-                .distinct()
-                .order_by("last_name")
+            .filter(groups__permissions__codename='case_manage_Patient')
+            .distinct()
+            .order_by("last_name")
         )
 
     def __init__(self, *args, **kwargs):
@@ -125,13 +128,13 @@ class UserInitForm(ModelForm):
         model = User
         fields = [
             'name',
-            'first_name', 
-            'last_name', 
-            'phone', 
-            'languages', 
-            'gender', 
+            'first_name',
+            'last_name',
+            'phone',
+            'languages',
+            'gender',
             'groups'
-            ]
+        ]
 
     def __init__(self, *args, **kwargs):
         super(UserInitForm, self).__init__(*args, **kwargs)
@@ -146,10 +149,10 @@ class UserInitForm(ModelForm):
         self.helper.add_input(Submit('submit', 'Submit'))
 
         required_fields = [
-            'first_name', 
-            'last_name', 
+            'first_name',
+            'last_name',
             'groups'
-            ]
+        ]
         for field in required_fields:
             self.fields[field].required = True
 
@@ -165,4 +168,3 @@ class DocumentForm(ModelForm):
         super(DocumentForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper(self)
         self.helper.add_input(Submit('submit', 'Submit'))
-


### PR DESCRIPTION
converted a few date/time fields to html date and time inputs instead of just text boxes. This gives a built-in date/time picker in the browser and client side date/time validation. 

@wwick did this as a way to poke around in the code so feel free to reject. also lmk about the linter changes (is there a default style preference, should i turn mine off?)
