### PR TITLE
Attending Panel Bug Fixes

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -346,7 +346,7 @@ OSLER_WORKUP_COPY_FORWARD_MESSAGE = (u"Migrated from previous workup on {date}. 
                                      u"the following as necessary:\n\n{contents}")
 
 # Dashboard settings
-OSLER_WORKUPS_PER_PAGE = 20
+OSLER_CLINIC_DAYS_PER_PAGE = 10
 
 OSLER_DEFAULT_DASHBOARD = 'dashboard-active'
 OSLER_ROLE_DASHBOARDS = {

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -346,7 +346,7 @@ OSLER_WORKUP_COPY_FORWARD_MESSAGE = (u"Migrated from previous workup on {date}. 
                                      u"the following as necessary:\n\n{contents}")
 
 # Dashboard settings
-OSLER_CLINIC_DAYS_PER_PAGE = 20
+OSLER_WORKUPS_PER_PAGE = 20
 
 OSLER_DEFAULT_DASHBOARD = 'dashboard-active'
 OSLER_ROLE_DASHBOARDS = {

--- a/osler/dashboard/tests.py
+++ b/osler/dashboard/tests.py
@@ -116,7 +116,7 @@ class TestAttendingDashboard(TestCase):
             Patient.objects.get(pk=1))
 
         # and one encounter with workup assigned to our attending
-        self.assertEqual(len(response.context['clinics']), 1)
+        assert len(response.context['wu_page']) == 1
         # with one patient
         self.assertContains(response, reverse('core:patient-detail',
                                               args=(self.pt2.pk,)))
@@ -130,7 +130,7 @@ class TestAttendingDashboard(TestCase):
         response = self.client.get(reverse('dashboard-attending'))
 
         # now two encounters with workup assigned to our attending
-        self.assertEqual(len(response.context['clinics']), 2)
+        assert len(response.context['wu_page']) == 2
         # with two patients
         self.assertContains(response, reverse('core:patient-detail',
                                               args=(self.pt2.pk,)))
@@ -139,7 +139,7 @@ class TestAttendingDashboard(TestCase):
         # ONE of which are marked as unattested
         self.assertContains(response, '<tr  class="warning" >', count=1)
 
-    @override_settings(OSLER_CLINIC_DAYS_PER_PAGE=3)
+    @override_settings(OSLER_WORKUPS_PER_PAGE=3)
     def test_dashboard_pagination(self):
         response = self.client.get(reverse('dashboard-attending'))
 
@@ -208,7 +208,7 @@ class TestAttendingDashboard(TestCase):
               </a></li>'''),
             dewhitespace(response.content.decode('utf-8')))
 
-    @override_settings(OSLER_CLINIC_DAYS_PER_PAGE=3)
+    @override_settings(OSLER_WORKUPS_PER_PAGE=3)
     def test_dashboard_page_out_of_range(self):
 
         for i in range(10):
@@ -236,7 +236,7 @@ class TestAttendingDashboard(TestCase):
         #Making 10 encounters with 3 per page, should make 4 pages
         #So the previous button should go towards the page before
         n_pages = (Encounter.objects.count() //
-                   settings.OSLER_CLINIC_DAYS_PER_PAGE)-1
+                   settings.OSLER_WORKUPS_PER_PAGE)-1
 
         # since we're on the last page, the "back" pagination button
         # should be enabled (i.e. no 'class="disabled"')

--- a/osler/dashboard/views.py
+++ b/osler/dashboard/views.py
@@ -5,12 +5,11 @@ from django.shortcuts import render, redirect
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.conf import settings
 
-from osler.workup.models import Encounter
+from osler.workup.models import Workup
 from osler.core.models import Patient
 from osler.core.views import all_patients
 
 from osler.users.utils import get_active_role
-from osler.core.utils import get_clindates
 
 
 def dashboard_dispatch(request):
@@ -31,33 +30,30 @@ def dashboard_dispatch(request):
 def dashboard_active(request):
     """Calls active patient dashboard filtered by patients needing workups."""
     
-
     return all_patients(request, title='Active Patients', active=True)
 
 
 def dashboard_attending(request):
     
-    encounter_list = Encounter.objects.filter(workup__attending=request.user).order_by('clinic_day')
-    clinic_list = get_clindates(encounter_list)
-
-    paginator = Paginator(encounter_list, settings.OSLER_CLINIC_DAYS_PER_PAGE,
+    wu_list = Workup.objects.filter(attending=request.user)
+    paginator = Paginator(wu_list, settings.OSLER_WORKUPS_PER_PAGE,
                           allow_empty_first_page=True)
 
     page = request.GET.get('page')
     try:
-        clinics = paginator.page(page)
+        wu_page = paginator.page(page)
     except PageNotAnInteger:
         # If page is not an integer, deliver first page.
-        clinics = paginator.page(1)
+        wu_page = paginator.page(1)
     except EmptyPage:
         # If page is out of range (e.g. 9999), deliver last page of results.
-        clinics = paginator.page(paginator.num_pages)
+        wu_page = paginator.page(paginator.num_pages)
 
-    no_note_patients = Patient.objects.filter(workup=None, encounter__status__is_active=True).order_by('-pk')[:20]
+
+    no_note_patients = Patient.objects.filter(workup=None, encounter__status__is_active=True).order_by('-pk')
 
     return render(request,
                   'dashboard/dashboard-attending.html',
-                  {'clinics': clinics,
-                  'clinic_list':clinic_list,
+                  {'wu_page': wu_page,
                    'no_note_patients': no_note_patients
                    })

--- a/osler/templates/dashboard/dashboard-attending.html
+++ b/osler/templates/dashboard/dashboard-attending.html
@@ -12,32 +12,40 @@
 
 {% block content %}
 
+{{ wu_list.count }}
+
 <div class="container">
-	{% for clinic in clinic_list %}
-		<h3>{{ clinic }}</h3>
+
+	{% regroup wu_page by encounter.clinic_day as clinic_day_list %}
+	{% for clinic_day in clinic_day_list %}
+		<h3>{{ clinic_day.grouper }}</h3>
 		<table class="table table-striped">
-			<tr>
-			    <th>{% trans 'Patient' %}</th>
-			    <th>{% trans 'Chief Complaint' %}</th>
-			    <th>{% trans 'Last Seen' %}</th>
-			    <th>{% trans 'Attending<' %}/th> 
-			    <th>{% trans 'Note Author' %}</th>
-			    <th>{% trans 'Attestation' %}</th>
-			</tr>
-		{% for encounter in clinics %}
-			{% if encounter.clinic_day == clinic %}
-				{% for wu in encounter.workup_set.all %}
-					<tr {% if wu.signer == None %} class="warning" {% endif %}>
-						<td><a href="{% url 'core:patient-detail' pk=wu.patient.id %}">{{ wu.patient }}</a></td>
-						<td><a href="{% url 'workup' pk=wu.id %}">{{ wu.chief_complaint }}</a></td>
-						<td>{{ wu.patient.last_seen | date:"D d M Y" }}</td>
-						<td>{{ wu.attending }}</td>
-						<td>{{ wu.author }}</td>
-						<td>{{ wu.signer | default_if_none:"unattested" }}</td>
-					</tr>
-				{% endfor %}
-			{% endif %}	
+		<thead>
+		<tr>
+			<th>{% trans 'Patient' %}</th>
+			<th>{% trans 'Chief Complaint' %}</th>
+			<th>{% trans 'Last Seen' %}</th>
+			<th>{% trans 'Attending' %}</th> 
+			<th>{% trans 'Note Author' %}</th>
+			<th>{% trans 'Attestation' %}</th>
+		</tr>
+		</thead>
+		<tbody>
+		{% for wu in clinic_day.list %}
+		<tr {% if wu.signer == None %} class="warning" {% endif %}>
+			<td><a href="{% url 'core:patient-detail' pk=wu.patient.id %}">{{ wu.patient }}</a></td>
+			<td><a href="{% url 'workup' pk=wu.id %}">{{ wu.chief_complaint }}</a></td>
+			<td>{{ wu.patient.last_seen | date:"D d M Y" }}</td>
+			<td>{{ wu.attending }}</td>
+			<td>{{ wu.author }}</td>
+			{% if wu.signer %}
+				<td>{{ wu.signer }}</td>
+			{% else %}
+				<td>{% trans "unattested" %}</td>
+			{% endif %}
+		</tr>
 		{% endfor %}
+		</tbody>
 		</table>
 	{% endfor %}
 
@@ -60,25 +68,25 @@
 
 	<nav aria-label="Page navigation" style='text-align: center;'>
 		<ul class="pagination">
-			<li {% if not clinics.has_previous %}class="disabled" {% endif %}>
-				<a {% if clinics.has_previous %} href="?page={{ clinics.previous_page_number }}" {% endif %} aria-label="Previous">
+			<li {% if not wu_page.has_previous %}class="disabled" {% endif %}>
+				<a {% if wu_page.has_previous %} href="?page={{ wu_page.previous_page_number }}" {% endif %} aria-label="Previous">
 					<span aria-hidden="true">&laquo;</span>
 				</a>
 			</li>
 
-			{% for i in clinics.paginator.page_range %}
-			<li {% if i == clinics.number %}class="active" {% endif %}><a href="?page={{ i }}">{{ i }}</a></li>
+			{% for i in wu_page.paginator.page_range %}
+			<li {% if i == wu_page.number %}class="active" {% endif %}><a href="?page={{ i }}">{{ i }}</a></li>
 			{% endfor %}
 
-			<li {% if not clinics.has_next %}class="disabled" {% endif %}>
-				<a {% if clinics.has_next %} href="?page={{ clinics.next_page_number }}" {% endif %} aria-label="Next">
+			<li {% if not wu_page.has_next %}class="disabled" {% endif %}>
+				<a {% if wu_page.has_next %} href="?page={{ wu_page.next_page_number }}" {% endif %} aria-label="Next">
 					<span aria-hidden="true">&raquo;</span>
 				</a>
 			</li>
 		</ul>
 	</nav>
 	<div>
-		<p style='text-align:center'>{% blocktrans %}Page {{ clinics.number }} of {{ clinics.paginator.num_pages }}{% endblocktrans %}</p>
+		<p style='text-align:center'>{% blocktrans %}Page {{ wu_page.number }} of {{ wu_page.paginator.num_pages }}{% endblocktrans %}</p>
 	</div>
 
 </div>

--- a/osler/templates/dashboard/dashboard-attending.html
+++ b/osler/templates/dashboard/dashboard-attending.html
@@ -16,9 +16,8 @@
 
 <div class="container">
 
-	{% regroup wu_page by encounter.clinic_day as clinic_day_list %}
-	{% for clinic_day in clinic_day_list %}
-		<h3>{{ clinic_day.grouper }}</h3>
+	{% for clinic_day, wu_list in clindate_page %}
+		<h3>{{ clinic_day }}</h3>
 		<table class="table table-striped">
 		<thead>
 		<tr>
@@ -31,7 +30,7 @@
 		</tr>
 		</thead>
 		<tbody>
-		{% for wu in clinic_day.list %}
+		{% for wu in wu_list %}
 		<tr {% if wu.signer == None %} class="warning" {% endif %}>
 			<td><a href="{% url 'core:patient-detail' pk=wu.patient.id %}">{{ wu.patient }}</a></td>
 			<td><a href="{% url 'workup' pk=wu.id %}">{{ wu.chief_complaint }}</a></td>
@@ -68,25 +67,25 @@
 
 	<nav aria-label="Page navigation" style='text-align: center;'>
 		<ul class="pagination">
-			<li {% if not wu_page.has_previous %}class="disabled" {% endif %}>
-				<a {% if wu_page.has_previous %} href="?page={{ wu_page.previous_page_number }}" {% endif %} aria-label="Previous">
+			<li {% if not clindate_page.has_previous %}class="disabled" {% endif %}>
+				<a {% if clindate_page.has_previous %} href="?page={{ clindate_page.previous_page_number }}" {% endif %} aria-label="Previous">
 					<span aria-hidden="true">&laquo;</span>
 				</a>
 			</li>
 
-			{% for i in wu_page.paginator.page_range %}
-			<li {% if i == wu_page.number %}class="active" {% endif %}><a href="?page={{ i }}">{{ i }}</a></li>
+			{% for i in clindate_page.paginator.page_range %}
+			<li {% if i == clindate_page.number %}class="active" {% endif %}><a href="?page={{ i }}">{{ i }}</a></li>
 			{% endfor %}
 
-			<li {% if not wu_page.has_next %}class="disabled" {% endif %}>
-				<a {% if wu_page.has_next %} href="?page={{ wu_page.next_page_number }}" {% endif %} aria-label="Next">
+			<li {% if not clindate_page.has_next %}class="disabled" {% endif %}>
+				<a {% if clindate_page.has_next %} href="?page={{ clindate_page.next_page_number }}" {% endif %} aria-label="Next">
 					<span aria-hidden="true">&raquo;</span>
 				</a>
 			</li>
 		</ul>
 	</nav>
 	<div>
-		<p style='text-align:center'>{% blocktrans %}Page {{ wu_page.number }} of {{ wu_page.paginator.num_pages }}{% endblocktrans %}</p>
+		<p style='text-align:center'>{% blocktrans %}Page {{ clindate_page.number }} of {{ clindate_page.paginator.num_pages }}{% endblocktrans %}</p>
 	</div>
 
 </div>


### PR DESCRIPTION
Addressed the following issues in Notion

- An issue with Attending panel - seems to populate multiple iterations of the same clinic date and same patients? New bug?
- Can we have attending panel/workflow page be in chronologic order (Most recent day on TOP)
